### PR TITLE
Feat: TDD Test Code용 DB 셋팅

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.6'
 }
 
-group = 'com.application'
+group = 'com.soothee'
 version = '0.0.1-SNAPSHOT'
 
 java {
@@ -34,6 +34,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation group: 'com.h2database', name: 'h2', version: '2.2.220'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/server/src/test/java/com/soothee/TestDBTest.java
+++ b/server/src/test/java/com/soothee/TestDBTest.java
@@ -1,0 +1,53 @@
+package com.soothee;
+
+import com.soothee.common.constants.SnsType;
+import com.soothee.member.entity.MemberEntity;
+import com.soothee.member.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource("classpath:application-test.properties")
+@SpringBootTest
+@Transactional
+public class TestDBTest {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private String memberName = "사용자0";
+    private String email = "abc@def.com";
+    private String isDelete = "N";
+    private SnsType snsType = SnsType.KAKAOTALK;
+
+    @Test
+    void 테스트디비에서_회원조회_성공하기() {
+        //given
+        MemberEntity member = memberRepository.findByMemberName(memberName);
+        //when
+        String email = member.getEmail();
+        //then
+        Assertions.assertThat(email).isEqualTo("abc@def.com");
+    }
+
+    @BeforeEach
+    void insertDefaultMember() {
+        MemberEntity member = MemberEntity.builder()
+                .memberName(memberName)
+                .email(email)
+                .isDelete(isDelete)
+                .snsType(snsType).build();
+        memberRepository.save(member);
+    }
+
+    @AfterEach
+    void deleteDefaultMember() {
+        memberRepository.deleteAll();
+    }
+}

--- a/server/src/test/resources/application-test.properties
+++ b/server/src/test/resources/application-test.properties
@@ -1,0 +1,16 @@
+
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true
+
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+logging.level.org.hibernate.type.descriptor.sql=trace
+
+#spring.sql.init.mode=always
+#spring.sql.init.schema-locations=classpath:schema.sql
+#spring.sql.init.data-locations=classpath:data.sql


### PR DESCRIPTION
## 📌 PR 개요
서비스 DB와 Test DB를 분리하여, 테스트 코드가 서비스에 영향을 미치지 않도록 함

## 📎 관련 이슈
관련 이슈가 있다면 이슈 번호를 기입해 주세요.  
`close #{KAN-62}`를 작성하면 요청이 merge된 후 이슈가 자동으로 close됩니다.

`resolve #(KAN-62)`

## 🔍 작업 내용
- [x] Test DB로 사용될 In-memory H2 database 의존성 추가
- [x] Test 용 properties 파일 생성 및 셋팅
- [x] 연결 확인 용 Test 코드 작성 및 테스트 통과 확인

## ✅ 체크리스트
- [x] 코드 스타일 가이드에 맞게 작성했나요?
- [ ] 코드에 대한 주석을 달았나요?
- [ ] 문서가 업데이트되었나요? (해당하는 경우)
- [x] 테스트가 추가되었거나 기존 테스트가 통과하나요?

## 📝 참고 사항
기존 User Table의 User가 H2database의 예약어와 겹쳐 Member로 변경

