### PR TITLE
Feat: API 명세서 자동 문서화 Swagger 설정

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation group: 'com.h2database', name: 'h2', version: '2.2.220'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/soothee/config/appConfig.java
+++ b/server/src/main/java/com/soothee/config/appConfig.java
@@ -1,7 +1,31 @@
 package com.soothee.config;
 
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class appConfig {
+    @Bean
+    public GroupedOpenApi memberGroupedOpenApi() {
+        return GroupedOpenApi.builder()
+                            .group("member")
+                            .pathsToMatch("/member/**")
+                            .addOpenApiCustomizer(openApi -> openApi.setInfo(new Info().title("Member API")
+                                                                                        .description("사용자 관련 처리")
+                                                                                        .version("1.0.0")))
+                            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi dairyGroupedOpenApi() {
+        return GroupedOpenApi.builder()
+                            .group("dairy")
+                            .pathsToMatch("/dairy/**")
+                            .addOpenApiCustomizer(openApi -> openApi.setInfo(new Info().title("Dairy API")
+                                                                                        .description("다이어리 관련 처리")
+                                                                                        .version("1.0.0")))
+                            .build();
+    }
 }

--- a/server/src/main/java/com/soothee/dairy/controller/DairyController.java
+++ b/server/src/main/java/com/soothee/dairy/controller/DairyController.java
@@ -1,9 +1,13 @@
 package com.soothee.dairy.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequiredArgsConstructor
+@Tag(name = "Dairy API", description = "다이어리 관련 처리")
+@RequestMapping("/dairy")
 public class DairyController {
 }

--- a/server/src/main/java/com/soothee/member/controller/MemberController.java
+++ b/server/src/main/java/com/soothee/member/controller/MemberController.java
@@ -1,9 +1,13 @@
 package com.soothee.member.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequiredArgsConstructor
+@Tag(name = "Member API", description = "회원 관련 처리")
+@RequestMapping("/member")
 public class MemberController {
 }


### PR DESCRIPTION
## 📌 PR 개요
API 명세 자동 생성을 위해 Swagger 추가

## 📎 관련 이슈
관련 이슈가 있다면 이슈 번호를 기입해 주세요.  
`close #{KAN-83}`를 작성하면 요청이 merge된 후 이슈가 자동으로 close됩니다.

`resolve #(KAN-83)`

## 🔍 작업 내용
- [x] Build.gradle에 Swagger 의존성 추가
- [x] Configuration에 Swagger 빈 생성
- [x] API 그룹(다이어리/회원) 생성
- [x] Controller에 API 명세에 사용할 Tag 추가

## ✅ 체크리스트
- [ ] 코드 스타일 가이드에 맞게 작성했나요?
- [ ] 코드에 대한 주석을 달았나요?
- [ ] 문서가 업데이트되었나요? (해당하는 경우)
- [ ] 테스트가 추가되었거나 기존 테스트가 통과하나요?

## 📝 참고 사항

