### PR TITLE
Feat: 회원 관련 API 구현

### DIFF
--- a/server/src/main/java/com/soothee/common/constants/ConstUrl.java
+++ b/server/src/main/java/com/soothee/common/constants/ConstUrl.java
@@ -2,31 +2,30 @@ package com.soothee.common.constants;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
-@Configuration
 @Getter
 @RequiredArgsConstructor
-@ConfigurationProperties(prefix = "soothee")
+@Component
 public class ConstUrl {
     /** Front Server Base URL */
-    private String frontUrl;
+    @Value("${soothee.front.url}")
+    private String FRONT_URL;
     /** OAuth2 로그인 Base URL */
-    private String loginBaseUrl;
-    /** 온보딩 페이지 URL */
-    private String onboardingUrl;
+    private final String LOGIN_BASE_URL = "/login/oauth2/callback/";
     /** 로그인 페이지 URL */
-    private String loginPageUrl;
+    private final String LOGIN_PAGE_URL = "/login";
     /** 로그인 성공 URL */
-    private String loginSuccessUrl;
+    private final String LOGIN_SUCCESS_URL = "/auth/success";
+    /** 온보딩 페이지 URL */
+    private final String ONBOARDING_URL = "/onBoarding";
     /** 홈 URL */
-    private String homepageUrl;
+    private final String HOMEPAGE_URL = "/home";
     /** Front CSS Path */
-    private String resourceCss;
+    private final String CSS = "/css";
     /** Front JS Path */
-    private String resourceJs;
+    private final String JS = "/js";
     /** Front IMAGE Path */
-    private String resourceImage;
+    private final String IMAGE = "/images";
 }

--- a/server/src/main/java/com/soothee/common/constants/ConstUrl.java
+++ b/server/src/main/java/com/soothee/common/constants/ConstUrl.java
@@ -1,27 +1,32 @@
 package com.soothee.common.constants;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@Getter
+@RequiredArgsConstructor
 @ConfigurationProperties(prefix = "soothee")
 public class ConstUrl {
     /** Front Server Base URL */
-    public static String FRONT_URL;
+    private String frontUrl;
     /** OAuth2 로그인 Base URL */
-    public static String BASE_LOGIN_URL;
+    private String loginBaseUrl;
     /** 온보딩 페이지 URL */
-    public static String ONBOARDING_URL;
+    private String onboardingUrl;
     /** 로그인 페이지 URL */
-    public static String LOGIN_PAGE_URL;
+    private String loginPageUrl;
     /** 로그인 성공 URL */
-    public static String LOGIN_SUCCESS_URL;
+    private String loginSuccessUrl;
     /** 홈 URL */
-    public static String HOMEPAGE_URL;
+    private String homepageUrl;
     /** Front CSS Path */
-    public static String RESOURCE_CSS;
+    private String resourceCss;
     /** Front JS Path */
-    public static String RESOURCE_JS;
+    private String resourceJs;
     /** Front IMAGE Path */
-    public static String RESOURCE_IMAGE;
+    private String resourceImage;
 }

--- a/server/src/main/java/com/soothee/common/constants/Role.java
+++ b/server/src/main/java/com/soothee/common/constants/Role.java
@@ -1,13 +1,12 @@
 package com.soothee.common.constants;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public enum Role {
     ADMIN("관리자"), USER("회원");
 
     private final String role;
-
-    Role(String role) {
-        this.role = role;
-    }
 
     public String toString(){
         return role;

--- a/server/src/main/java/com/soothee/common/constants/SnsType.java
+++ b/server/src/main/java/com/soothee/common/constants/SnsType.java
@@ -1,13 +1,12 @@
 package com.soothee.common.constants;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public enum SnsType {
     KAKAOTALK("kakao"), GOOGLE("google");
 
     private final String snsType;
-
-    SnsType(String snsType) {
-        this.snsType = snsType;
-    }
 
     public String toString(){
         return snsType;

--- a/server/src/main/java/com/soothee/common/exception/ErrorDTO.java
+++ b/server/src/main/java/com/soothee/common/exception/ErrorDTO.java
@@ -1,0 +1,25 @@
+package com.soothee.common.exception;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.ResponseEntity;
+
+@Builder
+@Data
+public class ErrorDTO {
+    private String msg;
+    private String detail;
+
+
+    public static ResponseEntity<ErrorDTO> toResponseEntity(MyException ex) {
+        MyErrorMsg errorMsg = ex.getErrorMsg();
+        String detail = ex.getDetail();
+
+        return ResponseEntity
+                .status(ex.getStatus())
+                .body(ErrorDTO.builder()
+                        .msg(errorMsg.toString())
+                        .detail(detail)
+                        .build());
+    }
+}

--- a/server/src/main/java/com/soothee/common/exception/ExceptionResponse.java
+++ b/server/src/main/java/com/soothee/common/exception/ExceptionResponse.java
@@ -6,18 +6,17 @@ import org.springframework.http.ResponseEntity;
 
 @Builder
 @Data
-public class ErrorDTO {
+public class ExceptionResponse {
     private String msg;
     private String detail;
 
-
-    public static ResponseEntity<ErrorDTO> toResponseEntity(MyException ex) {
+    public static ResponseEntity<ExceptionResponse> toResponseEntity(MyException ex) {
         MyErrorMsg errorMsg = ex.getErrorMsg();
         String detail = ex.getDetail();
 
         return ResponseEntity
                 .status(ex.getStatus())
-                .body(ErrorDTO.builder()
+                .body(ExceptionResponse.builder()
                         .msg(errorMsg.toString())
                         .detail(detail)
                         .build());

--- a/server/src/main/java/com/soothee/common/exception/MyErrorMsg.java
+++ b/server/src/main/java/com/soothee/common/exception/MyErrorMsg.java
@@ -5,7 +5,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MyErrorMsg {
     NOT_EXIST_MEMBER("해당 정보로 조회된 회원이 없습니다."),
-    NULL_VALUE("값이 없습니다.");
+    NULL_VALUE("값이 없습니다."),
+    MISS_MATCH_MEMBER("로그인한 회원의 정보가 아닙니다.");
 
     private final String msg;
 

--- a/server/src/main/java/com/soothee/common/exception/MyErrorMsg.java
+++ b/server/src/main/java/com/soothee/common/exception/MyErrorMsg.java
@@ -1,0 +1,15 @@
+package com.soothee.common.exception;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum MyErrorMsg {
+    NOT_EXIST_MEMBER("해당 정보로 조회된 회원이 없습니다."),
+    NULL_VALUE("값이 없습니다.");
+
+    private final String msg;
+
+    public String toString() {
+        return msg;
+    }
+}

--- a/server/src/main/java/com/soothee/common/exception/MyException.java
+++ b/server/src/main/java/com/soothee/common/exception/MyException.java
@@ -1,0 +1,54 @@
+package com.soothee.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class MyException extends RuntimeException {
+    private final HttpStatus status;
+    private final MyErrorMsg errorMsg;
+    private final String detail;
+
+    public MyException(HttpStatus status, MyErrorMsg errorMsg) {
+        this.status = status;
+        this.errorMsg = errorMsg;
+        this.detail = "";
+    }
+
+    public MyException(HttpStatus status, MyErrorMsg errorMsg, String detail) {
+        this.status = status;
+        this.errorMsg = errorMsg;
+        this.detail = detail;
+    }
+
+    public MyException(HttpStatus status, MyErrorMsg errorMsg, Throwable cause) {
+        this.status = status;
+        this.errorMsg = errorMsg;
+        this.detail = cause.getMessage();
+    }
+
+    public MyException(HttpStatus status, MyException myException) {
+        this.status = status;
+        this.errorMsg = myException.getErrorMsg();
+        this.detail = myException.getDetail();
+    }
+
+    public MyException(HttpStatus status, Throwable cause) {
+        this.status = status;
+        this.errorMsg = null;
+        this.detail = cause.getMessage();
+    }
+
+    public MyException(Exception exception) {
+        if (exception.getClass() == MyException.class) {
+            MyException myException = (MyException) exception;
+            this.status = myException.getStatus();
+            this.errorMsg = myException.getErrorMsg();
+            this.detail = myException.getMessage();
+        } else {
+            this.status = HttpStatus.BAD_REQUEST;
+            this.errorMsg = null;
+            this.detail = exception.getMessage();
+        }
+    }
+}

--- a/server/src/main/java/com/soothee/common/exception/MyExceptionHandler.java
+++ b/server/src/main/java/com/soothee/common/exception/MyExceptionHandler.java
@@ -1,0 +1,13 @@
+package com.soothee.common.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class MyExceptionHandler {
+    @ExceptionHandler(MyException.class)
+    protected ResponseEntity<ErrorDTO> handleCustom400Exception(MyException ex) {
+        return ErrorDTO.toResponseEntity(ex);
+    }
+}

--- a/server/src/main/java/com/soothee/common/exception/MyExceptionHandler.java
+++ b/server/src/main/java/com/soothee/common/exception/MyExceptionHandler.java
@@ -1,13 +1,14 @@
 package com.soothee.common.exception;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@ControllerAdvice
+@RestControllerAdvice
 public class MyExceptionHandler {
+
     @ExceptionHandler(MyException.class)
-    protected ResponseEntity<ErrorDTO> handleCustom400Exception(MyException ex) {
-        return ErrorDTO.toResponseEntity(ex);
+    protected ResponseEntity<ExceptionResponse> handleCustom400Exception(MyException ex) {
+        return ExceptionResponse.toResponseEntity(ex);
     }
 }

--- a/server/src/main/java/com/soothee/config/AppConfig.java
+++ b/server/src/main/java/com/soothee/config/AppConfig.java
@@ -28,7 +28,7 @@ public class AppConfig implements WebMvcConfigurer {
     /** Spring-Security 인증/인가 제외 설정 */
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/error",
+        return web -> web.ignoring().requestMatchers("/error/**", "/status",
                                                     "/favicon.ico",
                                                     ConstUrl.RESOURCE_CSS,
                                                     ConstUrl.RESOURCE_JS,

--- a/server/src/main/java/com/soothee/config/AppConfig.java
+++ b/server/src/main/java/com/soothee/config/AppConfig.java
@@ -44,11 +44,20 @@ public class AppConfig implements WebMvcConfigurer {
                     .logout(AbstractHttpConfigurer::disable)
                     .headers(configurer -> configurer.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                     .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                    .authorizeHttpRequests((requests) -> requests.requestMatchers(new AntPathRequestMatcher(ConstUrl.LOGIN_PAGE_URL),
-                                                                                    new AntPathRequestMatcher(ConstUrl.ONBOARDING_URL)).permitAll()
+                    .authorizeHttpRequests((requests) -> requests.requestMatchers(new AntPathRequestMatcher("/login"),
+                                                                                    new AntPathRequestMatcher("/onBoarding"),
+                                                                                    new AntPathRequestMatcher("/error/**"),
+                                                                                    new AntPathRequestMatcher("/status"),
+                                                                                    new AntPathRequestMatcher("/css"),
+                                                                                    new AntPathRequestMatcher("/js"),
+                                                                                    new AntPathRequestMatcher("/images"),
+                                                                                    new AntPathRequestMatcher("/swagger-ui/**"),
+                                                                                    new AntPathRequestMatcher("/api"),
+                                                                                    new AntPathRequestMatcher("/v3/**"),
+                                                                                    new AntPathRequestMatcher("/docs")).permitAll()
                                                                 .anyRequest().authenticated())
-                    .oauth2Login((configurer) -> configurer.redirectionEndpoint((endpoint) -> endpoint.baseUri(ConstUrl.BASE_LOGIN_URL))
-                                                            .defaultSuccessUrl(ConstUrl.HOMEPAGE_URL)).build();
+                    .oauth2Login((configurer) -> configurer.redirectionEndpoint((endpoint) -> endpoint.baseUri("/login/oauth2/callback/"))
+                                                            .defaultSuccessUrl("/home")).build();
     }
 
     /** Swagger 회원 API 명세서 */

--- a/server/src/main/java/com/soothee/config/AppConfig.java
+++ b/server/src/main/java/com/soothee/config/AppConfig.java
@@ -1,13 +1,19 @@
 package com.soothee.config;
 
 import com.soothee.common.constants.ConstUrl;
-import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.*;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -18,21 +24,37 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @EnableWebSecurity
+@OpenAPIDefinition(
+        security = @SecurityRequirement(name = "oauth2_auth"),
+        info = @Info(
+                title = "SOOTHEE",
+                version = "1.0",
+                description = "Soothee API DOC"
+        )
+)
+@SecurityScheme(
+        name = "oauth2_auth",
+        type = SecuritySchemeType.OAUTH2,
+        flows = @OAuthFlows(
+                authorizationCode = @OAuthFlow(
+                        authorizationUrl = "https://auth-server.com/oauth/authorize",
+                        tokenUrl = "https://auth-server.com/oauth/token",
+                        scopes = {
+                                @OAuthScope(name = "read", description = "Read access"),
+                                @OAuthScope(name = "write", description = "Write access")
+                        }
+                )
+        )
+)
+@SecurityRequirement(name = "bearerAuth")
+@RequiredArgsConstructor
 public class AppConfig implements WebMvcConfigurer {
+    private final ConstUrl constUrl;
+
     /** Front-Server & Back-Server 간 CORS 설정 */
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**").allowedOrigins(ConstUrl.FRONT_URL);
-    }
-
-    /** Spring-Security 인증/인가 제외 설정 */
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/error/**", "/status",
-                                                    "/favicon.ico",
-                                                    ConstUrl.RESOURCE_CSS,
-                                                    ConstUrl.RESOURCE_JS,
-                                                    ConstUrl.RESOURCE_IMAGE);
+        registry.addMapping("/**").allowedOrigins(constUrl.getFRONT_URL());
     }
 
     /** Spring-Security 설정 */
@@ -66,9 +88,14 @@ public class AppConfig implements WebMvcConfigurer {
         return GroupedOpenApi.builder()
                             .group("member")
                             .pathsToMatch("/member/**")
-                            .addOpenApiCustomizer(openApi -> openApi.setInfo(new Info().title("Member API")
-                                                                                        .description("사용자 관련 처리")
-                                                                                        .version("1.0.0")))
+                            .addOpenApiCustomizer(openApi -> {
+                                openApi.setInfo(new io.swagger.v3.oas.models.info.Info().title("Member API")
+                                                                                            .description("회원 관련 처리")
+                                                                                            .version("1.0.0"));
+                                openApi.addSecurityItem(
+                                        new io.swagger.v3.oas.models.security.SecurityRequirement().addList("oauth2_auth")
+                                );
+                            })
                             .build();
     }
 
@@ -78,9 +105,14 @@ public class AppConfig implements WebMvcConfigurer {
         return GroupedOpenApi.builder()
                             .group("dairy")
                             .pathsToMatch("/dairy/**")
-                            .addOpenApiCustomizer(openApi -> openApi.setInfo(new Info().title("Dairy API")
+                            .addOpenApiCustomizer(openApi -> {
+                                openApi.setInfo(new io.swagger.v3.oas.models.info.Info().title("Dairy API")
                                                                                         .description("다이어리 관련 처리")
-                                                                                        .version("1.0.0")))
+                                                                                        .version("1.0.0"));
+                                openApi.addSecurityItem(
+                                        new io.swagger.v3.oas.models.security.SecurityRequirement().addList("oauth2_auth")
+                                );
+                            })
                             .build();
     }
 }

--- a/server/src/main/java/com/soothee/member/controller/MemberController.java
+++ b/server/src/main/java/com/soothee/member/controller/MemberController.java
@@ -1,13 +1,38 @@
 package com.soothee.member.controller;
 
+import com.soothee.common.exception.MyErrorMsg;
+import com.soothee.member.domain.Member;
+import com.soothee.member.dto.UpdateMemberDTO;
+import com.soothee.member.service.MemberService;
+import io.micrometer.common.util.StringUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.security.Principal;
+import java.util.Objects;
 
 @Controller
 @RequiredArgsConstructor
 @Tag(name = "Member API", description = "회원 관련 처리")
 @RequestMapping("/member")
 public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping("/update")
+    public ResponseEntity<?> updateMemberName(Principal principal) {
+        String loginId = principal.getName();
+        Member loginMember = memberService.getMemberByEmail(loginId);
+        UpdateMemberDTO result = UpdateMemberDTO.builder()
+                .id(loginMember.getId())
+                .memberName(loginMember.getMemberName()).build();
+        if (Objects.isNull(loginMember.getId()) || StringUtils.isBlank(loginMember.getMemberName())) {
+            return new ResponseEntity<String>(MyErrorMsg.NULL_VALUE.toString(), HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<UpdateMemberDTO>(result, HttpStatus.OK);
+    }
 }

--- a/server/src/main/java/com/soothee/member/controller/MemberController.java
+++ b/server/src/main/java/com/soothee/member/controller/MemberController.java
@@ -5,6 +5,12 @@ import com.soothee.member.domain.Member;
 import com.soothee.member.dto.UpdateMemberDTO;
 import com.soothee.member.service.MemberService;
 import io.micrometer.common.util.StringUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,6 +30,15 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/update")
+    @Operation(summary = "회원의 현재 닉네임", description = "회원 닉네임 변경 세팅 창에서 닉네임을 바꾸기 전에 현재 닉네임을 먼저 출력")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "404", description = "회원 정보 없음", content = @Content(mediaType = "text/plain"))
+    })
+    @Parameters({
+            @Parameter(name = "id", description = "회원 고유일련번호", example = "1112"),
+            @Parameter(name = "member_name", description = "회원 닉네임", example = "사용자")
+    })
     public ResponseEntity<?> updateMemberName(Principal principal) {
         String loginId = principal.getName();
         Member loginMember = memberService.getMemberByEmail(loginId);

--- a/server/src/main/java/com/soothee/member/controller/MemberController.java
+++ b/server/src/main/java/com/soothee/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,7 +31,8 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/update")
-    @Operation(summary = "회원의 현재 닉네임", description = "회원 닉네임 변경 세팅 창에서 닉네임을 바꾸기 전에 현재 닉네임을 먼저 출력")
+    @Operation(summary = "회원의 현재 닉네임", description = "회원 닉네임 변경 세팅 창에서 닉네임을 바꾸기 전에 현재 닉네임을 먼저 출력",
+            security = @SecurityRequirement(name = "oauth2_auth"))
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(mediaType = "application/json")),
         @ApiResponse(responseCode = "404", description = "회원 정보 없음", content = @Content(mediaType = "text/plain"))

--- a/server/src/main/java/com/soothee/member/domain/Member.java
+++ b/server/src/main/java/com/soothee/member/domain/Member.java
@@ -64,21 +64,16 @@ public class Member extends TimeEntity {
     /**
      * 회원 정보 수정</hr>
      *
-     * @param member Member 해당 멤버
+     * @param memberName String: 바꿀 회원 닉네임
      */
-    public void updateMember(Member member) {
-        //todo email 형식 검사
-        this.email = email;
+    public void updateMember(String memberName) {
+        this.memberName = memberName;
     }
 
     /**
      * 회원 삭제</hr>
-     *
-     * @param member Member 해당 맴버
      */
-    public void deleteMember(Member member) {
-        if (StringUtils.equals(member.getId(), this.getId())) {
-            this.isDelete = "Y";
-        }
+    public void deleteMember() {
+        this.isDelete = "Y";
     }
 }

--- a/server/src/main/java/com/soothee/member/dto/UpdateMemberDTO.java
+++ b/server/src/main/java/com/soothee/member/dto/UpdateMemberDTO.java
@@ -1,0 +1,13 @@
+package com.soothee.member.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@Setter
+@Getter
+@AllArgsConstructor
+@Builder
+public class UpdateMemberDTO {
+    private Long id;
+    private String memberName;
+}

--- a/server/src/main/java/com/soothee/member/dto/UpdateMemberDTO.java
+++ b/server/src/main/java/com/soothee/member/dto/UpdateMemberDTO.java
@@ -1,5 +1,6 @@
 package com.soothee.member.dto;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
 
 @NoArgsConstructor
@@ -8,6 +9,8 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class UpdateMemberDTO {
+    @NotEmpty(message = "회원 일련번호가 없습니다.")
     private Long id;
+    @NotEmpty(message = "회원 닉네임이 없습니다.")
     private String memberName;
 }

--- a/server/src/main/java/com/soothee/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/soothee/member/repository/MemberRepository.java
@@ -10,12 +10,12 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     /**
-     * 회원 닉네임으로 회원 조회</hr>
+     * 회원 이메일로 회원 조회</hr>
      *
-     * @param memberName String : 조회할 회원 닉네임
+     * @param email String : 조회할 회원 이메일
      * @return Member : 해당 회원
      */
-    Optional<Member> findByMemberName(String memberName);
+    Optional<Member> findByEmail(String email);
 
     /** 인증 회원 식별자와 SNS 종류로 회원 조회</hr>
      *

--- a/server/src/main/java/com/soothee/member/service/MemberService.java
+++ b/server/src/main/java/com/soothee/member/service/MemberService.java
@@ -2,7 +2,9 @@ package com.soothee.member.service;
 
 import com.soothee.common.constants.SnsType;
 import com.soothee.member.domain.Member;
+import com.soothee.member.dto.UpdateMemberDTO;
 
+import java.security.Principal;
 import java.util.Optional;
 
 public interface MemberService {
@@ -20,10 +22,31 @@ public interface MemberService {
      */
     void saveMember(Member member);
 
-    /** 로그인한 아이디(이메일)로 회원 정보 조회</hr>
+    /** 회원 닉네임 수정</hr>
      *
-     * @param loginId String : 로그인한 회원 이메일
-     * @return Member : 로그인한 회원의 정보
+     * @param loginMember Member : 현재 로그인한 회원 정보
+     * @param updateInfo UpdateMemberDTO: 수정할 회원의 정보
      */
-    Member getMemberByEmail(String loginId);
+    void updateMember(Member loginMember, UpdateMemberDTO updateInfo);
+
+    /** 회원 탈퇴</hr>
+     *
+     * @param loginMember Member : 현재 로그인한 회원 정보
+     */
+    void deleteMember(Member loginMember);
+
+    /** 현재 로그인한 회원 정보 가져오기</hr>
+     *
+     * @param principal Principal : 현재 로그인 계정 정보
+     * @return Member: 로그인한 회원의 정보
+     */
+    Member getLoginMember(Principal principal);
+
+    /** 로그인한 회원의 정보와 입력된 회원의 정보가 일치하지 않는지 확인</hr>
+     *
+     * @param loginInfo Member : 로그인한 회원 정보
+     * @param inputInfo UpdateMemberDTO : 입력한 회원 정보
+     * @return 일치하면 false, 아니면 true
+     */
+    boolean isNotLoginMemberInfo(Member loginInfo, UpdateMemberDTO inputInfo);
 }

--- a/server/src/main/java/com/soothee/member/service/MemberService.java
+++ b/server/src/main/java/com/soothee/member/service/MemberService.java
@@ -6,7 +6,6 @@ import com.soothee.member.domain.Member;
 import java.util.Optional;
 
 public interface MemberService {
-
     /** OAuth2 로그인 시, 받은 정보로 회원 조회</hr>
      *
      * @param oauth2ClientId String : OAuth2 로그인용 ID
@@ -20,4 +19,11 @@ public interface MemberService {
      * @param member Member : 가입할 회원의 정보
      */
     void saveMember(Member member);
+
+    /** 로그인한 아이디(이메일)로 회원 정보 조회</hr>
+     *
+     * @param loginId String : 로그인한 회원 이메일
+     * @return Member : 로그인한 회원의 정보
+     */
+    Member getMemberByEmail(String loginId);
 }

--- a/server/src/main/java/com/soothee/member/service/MemberServiceImpl.java
+++ b/server/src/main/java/com/soothee/member/service/MemberServiceImpl.java
@@ -4,12 +4,15 @@ import com.soothee.common.constants.SnsType;
 import com.soothee.common.exception.MyErrorMsg;
 import com.soothee.common.exception.MyException;
 import com.soothee.member.domain.Member;
+import com.soothee.member.dto.UpdateMemberDTO;
 import com.soothee.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.Principal;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -36,14 +39,46 @@ public class MemberServiceImpl implements MemberService {
         memberRepository.save(member);
     }
 
-    /** 로그인한 아이디(이메일)로 회원 정보 조회</hr>
+    /** 회원 닉네임 수정</hr>
      *
-     * @param loginId String : 로그인한 회원 이메일
-     * @return Member : 로그인한 회원의 정보
+     * @param loginMember Member : 현재 로그인한 회원 정보
+     * @param updateInfo UpdateMemberDTO: 수정할 회원의 정보
      */
     @Override
-    public Member getMemberByEmail(String loginId) {
+    public void updateMember(Member loginMember, UpdateMemberDTO updateInfo) {
+        loginMember.updateMember(updateInfo.getMemberName());
+    }
+
+    /** 회원 탈퇴</hr>
+     *
+     * @param loginMember Member : 현재 로그인한 회원 정보
+     */
+    @Override
+    public void deleteMember(Member loginMember) {
+        loginMember.deleteMember();
+    }
+
+    /**
+     * 현재 로그인한 회원 정보 가져오기</hr>
+     *
+     * @param principal Principal : 현재 로그인 계정 정보
+     * @return Member: 로그인한 회원의 정보
+     */
+    @Override
+    public Member getLoginMember(Principal principal) {
+        String loginId = principal.getName();
         Optional<Member> optional =  memberRepository.findByEmail(loginId);
         return optional.orElseThrow(() -> new MyException(HttpStatus.NOT_FOUND, MyErrorMsg.NOT_EXIST_MEMBER));
+    }
+
+    /** 로그인한 회원의 정보와 입력된 회원의 정보가 일치하지 않는지 확인</hr>
+     *
+     * @param loginInfo Member : 로그인한 회원 정보
+     * @param inputInfo UpdateMemberDTO : 입력한 회원 정보
+     * @return 일치하면 false, 아니면 true
+     */
+    @Override
+    public boolean isNotLoginMemberInfo(Member loginInfo, UpdateMemberDTO inputInfo) {
+        return !Objects.equals(loginInfo.getId(), inputInfo.getId());
     }
 }

--- a/server/src/main/java/com/soothee/member/service/MemberServiceImpl.java
+++ b/server/src/main/java/com/soothee/member/service/MemberServiceImpl.java
@@ -1,9 +1,12 @@
 package com.soothee.member.service;
 
 import com.soothee.common.constants.SnsType;
+import com.soothee.common.exception.MyErrorMsg;
+import com.soothee.common.exception.MyException;
 import com.soothee.member.domain.Member;
 import com.soothee.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,5 +34,16 @@ public class MemberServiceImpl implements MemberService {
      */
     public void saveMember(Member member) {
         memberRepository.save(member);
+    }
+
+    /** 로그인한 아이디(이메일)로 회원 정보 조회</hr>
+     *
+     * @param loginId String : 로그인한 회원 이메일
+     * @return Member : 로그인한 회원의 정보
+     */
+    @Override
+    public Member getMemberByEmail(String loginId) {
+        Optional<Member> optional =  memberRepository.findByEmail(loginId);
+        return optional.orElseThrow(() -> new MyException(HttpStatus.NOT_FOUND, MyErrorMsg.NOT_EXIST_MEMBER));
     }
 }

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,19 +1,20 @@
 spring.application.name=soothee
+
 # DB ??
 spring.profiles.active=dev
+
 # OAuth2 ??
 spring.profiles.include=oauth2
-
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.type.descriptor.sql=trace
 
 # URLs
-soothee.onBoardingUrl="/onBoarding"
-soothee.loginPageUrl="/login"
-soothee.baseLoginUri="/login/oauth2/callback/"
-soothee.loginSuccessUrl="/auth/success"
-soothee.homepageUrl="/home"
-soothee.resource.css=${soothee.frontUrl}""
-soothee.resource.js=${soothee.frontUrl}""
-soothee.resource.image=${soothee.frontUrl}""
+soothee.onboarding.url=/onBoarding
+soothee.login.page.url=/login
+soothee.login.base.uri=/login/oauth2/callback/
+soothee.login.success.url=/auth/success
+soothee.homepage.url=/home
+soothee.resource.css=${soothee.frontUrl}/css
+soothee.resource.js=${soothee.frontUrl}/js
+soothee.resource.image=${soothee.frontUrl}/images

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -9,12 +9,16 @@ spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.type.descriptor.sql=trace
 
-# URLs
-soothee.onboarding.url=/onBoarding
-soothee.login.page.url=/login
-soothee.login.base.uri=/login/oauth2/callback/
-soothee.login.success.url=/auth/success
-soothee.homepage.url=/home
-soothee.resource.css=${soothee.frontUrl}/css
-soothee.resource.js=${soothee.frontUrl}/js
-soothee.resource.image=${soothee.frontUrl}/images
+#Swagger
+springdoc.api-docs.enabled=true
+springdoc.api-docs.path=/docs
+springdoc.swagger-ui.enabled=true
+springdoc.swagger-ui.path=/api
+springdoc.swagger-ui.groups-order=DESC
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.operations-sorter=alpha
+springdoc.default-consumes-media-type=application/json;charset=UTF-8
+springdoc.default-produces-media-type=application/json;charset=UTF-8
+
+
+

--- a/server/src/test/java/com/soothee/TestDBTest.java
+++ b/server/src/test/java/com/soothee/TestDBTest.java
@@ -30,12 +30,12 @@ public class TestDBTest {
     @Test
     void 테스트디비에서_회원조회_성공하기() {
         //given
-        Optional<Member> optional = memberRepository.findByMemberName(memberName);
+        Optional<Member> optional = memberRepository.findByEmail(email);
         Member member = optional.get();
         //when
-        String email = member.getEmail();
+        String nickname = member.getEmail();
         //then
-        Assertions.assertThat(email).isEqualTo("abc@def.com");
+        Assertions.assertThat(nickname).isEqualTo(memberName);
     }
 
     @BeforeEach

--- a/server/src/test/java/com/soothee/member/controller/MemberControllerTest.java
+++ b/server/src/test/java/com/soothee/member/controller/MemberControllerTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class MemberControllerTest {
+  
+}

--- a/server/src/test/java/com/soothee/member/repository/MemberRepositoryTest.java
+++ b/server/src/test/java/com/soothee/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.soothee.member.repository;
+
+import com.soothee.common.constants.Role;
+import com.soothee.common.constants.SnsType;
+import com.soothee.member.domain.Member;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class MemberRepositoryTest {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        Member member = Member.builder()
+                            .role(Role.USER)
+                            .email("abc@abc.com")
+                            .memberName("사용자")
+                            .snsType(SnsType.KAKAOTALK)
+                            .oauth2ClientId("111")
+                            .build();
+        memberRepository.save(member);
+    }
+
+    @Test
+    void findByEmail() {
+        //given - setUp()
+        //when
+        Optional<Member> optional = memberRepository.findByEmail("abc@abc.com");
+        Member findMember = optional.orElseGet(() -> Member.builder().build());
+        String expectedMemberName = findMember.getMemberName();
+        //then
+        Assertions.assertThat(expectedMemberName).isEqualTo("사용자");
+
+    }
+
+    @Test
+    void findByOauth2ClientIdAndSnsType() {
+        //given - setUp()
+        //when
+        Optional<Member> optional = memberRepository.findByOauth2ClientIdAndSnsType("111", SnsType.KAKAOTALK);
+        Member findMember = optional.orElseGet(() -> Member.builder().build());
+        String expectedMemberName = findMember.getMemberName();
+        //then
+        Assertions.assertThat(expectedMemberName).isEqualTo("사용자");
+    }
+
+    @AfterEach
+    void tearDown() {
+
+    }
+}


### PR DESCRIPTION
## 📌 PR 개요
1. 회원 닉네임 수정
2. 회원 탈퇴
기능 구현

## 📎 관련 이슈
관련 이슈가 있다면 이슈 번호를 기입해 주세요.  
`close #{KAN-84}`를 작성하면 요청이 merge된 후 이슈가 자동으로 close됩니다.

`resolve #(KAN-84)`

## 🔍 작업 내용
- [x] 회원 닉네임 수정 페이지 조회 시, 기존 닉네임 출력 API 구현
- [x] 회원 닉네임 수정 API 구현
- [x] 회원 탈퇴 소프트삭제 API 구현

## ✅ 체크리스트
- [x] 코드 스타일 가이드에 맞게 작성했나요?
- [x] 코드에 대한 주석을 달았나요?
- [x] 문서가 업데이트되었나요? (해당하는 경우)
- [ ] 테스트가 추가되었거나 기존 테스트가 통과하나요?

## 📝 참고 사항

