### PR TITLE
Feat: 회원 API TestCode 작성

### DIFF
--- a/server/src/main/java/com/soothee/member/controller/MemberController.java
+++ b/server/src/main/java/com/soothee/member/controller/MemberController.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -85,7 +84,7 @@ public class MemberController {
     public ResponseEntity<?> updateName(@RequestParam("memberId") Long memberId,
                                               @RequestParam("name") String name,
                                               @AuthenticationPrincipal AuthenticatedUser loginInfo) {
-        memberService.updateMember(loginInfo, memberId, name);
+        memberService.updateName(loginInfo, memberId, name);
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 

--- a/server/src/main/java/com/soothee/member/service/MemberService.java
+++ b/server/src/main/java/com/soothee/member/service/MemberService.java
@@ -32,7 +32,7 @@ public interface MemberService {
      * @param memberId Long : 입력한 회원 일련번호
      * @param updateMode String : 변경할 모드
      */
-    void updateMember(AuthenticatedUser loginInfo, Long memberId, String updateMode);
+    void updateName(AuthenticatedUser loginInfo, Long memberId, String updateMode);
 
     /**
      * 회원 다크모드 수정</hr>
@@ -52,7 +52,7 @@ public interface MemberService {
     void deleteMember(AuthenticatedUser loginInfo, Long memberId);
 
     /**
-     * 마이페이지에 보여질 회원의 정보 조회</hr>
+     * 로그인한 회원의 모든 정보 조회</hr>
      *
      * @param loginInfo AuthenticatedUser : 로그인한 회원 정보
      * @return AllMemberInfo : 회원의 모든 정보
@@ -60,7 +60,7 @@ public interface MemberService {
     AllMemberInfoDTO getAllMemberInfo(AuthenticatedUser loginInfo);
 
     /**
-     * 회원의 닉네임만 조회</hr>
+     * 로그인한 회원의 닉네임만 조회</hr>
      *
      * @param loginInfo AuthenticatedUser : 로그인한 회원 정보
      * @return NameMemberInfoDTO : 회원 일련번호와 닉네임 정보

--- a/server/src/main/java/com/soothee/member/service/MemberServiceImpl.java
+++ b/server/src/main/java/com/soothee/member/service/MemberServiceImpl.java
@@ -5,7 +5,6 @@ import com.soothee.common.exception.MyErrorMsg;
 import com.soothee.common.exception.MyException;
 import com.soothee.member.domain.Member;
 import com.soothee.member.dto.AllMemberInfoDTO;
-import com.soothee.member.dto.MemberDTO;
 import com.soothee.member.dto.NameMemberInfoDTO;
 import com.soothee.member.repository.MemberRepository;
 import com.soothee.oauth2.domain.AuthenticatedUser;
@@ -55,7 +54,7 @@ public class MemberServiceImpl implements MemberService {
      * @param updateName String : 변경할 닉네임
      */
     @Override
-    public void updateMember(AuthenticatedUser loginInfo, Long memberId, String updateName) {
+    public void updateName(AuthenticatedUser loginInfo, Long memberId, String updateName) {
         Member loginMember = this.getLoginMember(loginInfo);
         if(this.isNotLoginMemberInfo(loginMember, memberId)) {
             throw new MyException(HttpStatus.BAD_REQUEST, MyErrorMsg.MISS_MATCH_MEMBER);
@@ -95,7 +94,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 마이페이지에 보여질 회원의 정보 조회</hr>
+     * 로그인한 회원의 모든 정보 조회</hr>
      *
      * @param loginInfo AuthenticatedUser : 로그인한 회원 정보
      * @return AllMemberInfo : 회원의 모든 정보
@@ -110,7 +109,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 회원의 닉네임만 조회</hr>
+     * 로그인한 회원의 닉네임만 조회</hr>
      *
      * @param loginInfo AuthenticatedUser : 로그인한 회원 정보
      * @return NameMemberInfoDTO : 회원 일련번호와 닉네임 정보

--- a/server/src/test/java/com/soothee/TestDBTest.java
+++ b/server/src/test/java/com/soothee/TestDBTest.java
@@ -22,35 +22,35 @@ import java.util.Optional;
 public class TestDBTest {
     @Autowired
     private MemberRepository memberRepository;
-
-    private String name = "사용자0";
-    private String email = "abc@def.com";
-    private SnsType snsType = SnsType.KAKAOTALK;
-    private String oauth2ClientId = "111111";
+    private final String NAME = "사용자0";
+    private final String EMAIL = "abc@def.com";
+    private final SnsType SNS_TYPE = SnsType.KAKAOTALK;
+    private final String OAUTH2_CLIENT_ID = "111111";
+    private Member member;
 
     @Test
     void 테스트디비에서_회원조회_성공하기() {
         //given
-        Optional<Member> optional = memberRepository.findByEmail(email);
+        Optional<Member> optional = memberRepository.findByEmail(EMAIL);
         Member member = optional.get();
         //when
         String nickname = member.getName();
         //then
-        Assertions.assertThat(nickname).isEqualTo(name);
+        Assertions.assertThat(nickname).isEqualTo(NAME);
     }
 
     @BeforeEach
     void insertDefaultMember() {
-        Member member = Member.builder()
-                .name(name)
-                .email(email)
-                .oauth2ClientId(oauth2ClientId)
-                .snsType(snsType).build();
+        member = Member.builder()
+                .name(NAME)
+                .email(EMAIL)
+                .oauth2ClientId(OAUTH2_CLIENT_ID)
+                .snsType(SNS_TYPE).build();
         memberRepository.save(member);
     }
 
     @AfterEach
     void deleteDefaultMember() {
-        memberRepository.deleteAll();
+        memberRepository.delete(member);
     }
 }

--- a/server/src/test/java/com/soothee/member/controller/MemberControllerTest.java
+++ b/server/src/test/java/com/soothee/member/controller/MemberControllerTest.java
@@ -1,4 +1,80 @@
+package com.soothee.member.controller;
+
+import com.soothee.common.constants.SnsType;
+import com.soothee.member.domain.Member;
+import com.soothee.member.service.MemberService;
+import com.soothee.oauth2.service.DelegatingOAuth2Service;
+import com.soothee.oauth2.service.GoogleOAuth2UserService;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.annotation.SecurityTestExecutionListeners;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 class MemberControllerTest {
-  
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private MemberController memberController;
+    @Autowired
+    private WebApplicationContext context;
+    @Autowired
+    private GoogleOAuth2UserService googleOAuth2UserService;
+    @Autowired
+    private MemberService memberService;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(this.context)
+                .apply(SecurityMockMvcConfigurers.springSecurity())
+                .build();
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("회원 정보 가져오기 성공")
+    void sendMemberInfo() throws Exception {
+        //given
+        Member member = Member.builder()
+                .email("abc@abc.com")
+                .oauth2ClientId("1111")
+                .snsType(SnsType.KAKAOTALK)
+                .name("test")
+                .build();
+        memberService.saveMember(member);
+
+        //when
+        mockMvc.perform(get("/member/info")).andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(member.getEmail()));
+    }
+
+    @Test
+    void updateDarkMode() {
+    }
+
+    @Test
+    void updateName() {
+    }
+
+    @Test
+    void deleteMember() {
+    }
 }

--- a/server/src/test/java/com/soothee/member/domain/MemberTest.java
+++ b/server/src/test/java/com/soothee/member/domain/MemberTest.java
@@ -1,0 +1,87 @@
+package com.soothee.member.domain;
+
+import com.soothee.common.constants.SnsType;
+import com.soothee.member.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource("classpath:application-test.properties")
+@SpringBootTest
+@Transactional
+class MemberTest {
+    @Autowired
+    private MemberRepository memberRepository;
+    private final String NAME = "사용자0";
+    private final String EMAIL = "abc@def.com";
+    private final SnsType SNS_TYPE = SnsType.KAKAOTALK;
+    private final String OAUTH2_CLIENT_ID = "111111";
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .name(NAME)
+                .email(EMAIL)
+                .oauth2ClientId(OAUTH2_CLIENT_ID)
+                .snsType(SNS_TYPE).build();
+        memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("회원 닉네임 수정 성공")
+    void updateName() {
+        //given
+        String newName = "수정한이름";
+        Member mem1 = memberRepository.getReferenceById(member.getId());
+
+        //when
+        mem1.updateName(newName);
+
+        //then
+        Member mem2 = memberRepository.getReferenceById(member.getId());
+        Assertions.assertThat(newName).isEqualTo(mem2.getName());
+    }
+
+    @Test
+    @DisplayName("회원 다크모드 수정 성공")
+    void updateDarkModeYN() {
+        //given
+        String isDarkY = "Y";
+        Member mem1 = memberRepository.getReferenceById(member.getId());
+
+        //when
+        mem1.updateDarkModeYN(isDarkY);
+
+        //then
+        Member mem2 = memberRepository.getReferenceById(member.getId());
+        Assertions.assertThat(isDarkY).isEqualTo(mem2.getIsDark());
+    }
+
+    @Test
+    @DisplayName("회원 삭제 성공")
+    void deleteMember() {
+        //given
+        Member mem1 = memberRepository.getReferenceById(member.getId());
+
+        //when
+        mem1.deleteMember();
+
+        //then
+        Member mem2 = memberRepository.getReferenceById(member.getId());
+        Assertions.assertThat("Y").isEqualTo(mem2.getIsDelete());
+    }
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.delete(member);
+    }
+}

--- a/server/src/test/java/com/soothee/member/repository/MemberRepositoryTest.java
+++ b/server/src/test/java/com/soothee/member/repository/MemberRepositoryTest.java
@@ -1,61 +1,76 @@
 package com.soothee.member.repository;
 
-import com.soothee.common.constants.Role;
 import com.soothee.common.constants.SnsType;
 import com.soothee.member.domain.Member;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.TestPropertySource;
 
 import java.util.Optional;
 
-@ExtendWith(SpringExtension.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource("classpath:application-test.properties")
 @DataJpaTest
 class MemberRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;
+    private final String NAME = "사용자0";
+    private final String EMAIL = "abc@def.com";
+    private final SnsType SNS_TYPE = SnsType.KAKAOTALK;
+    private final String OAUTH2_CLIENT_ID = "111111";
+    private Member member;
 
     @BeforeEach
     void setUp() {
-        Member member = Member.builder()
-                            .email("abc@abc.com")
-                            .name("사용자")
-                            .snsType(SnsType.KAKAOTALK)
-                            .oauth2ClientId("111")
-                            .build();
+        member = Member.builder()
+                .name(NAME)
+                .email(EMAIL)
+                .oauth2ClientId(OAUTH2_CLIENT_ID)
+                .snsType(SNS_TYPE).build();
         memberRepository.save(member);
     }
 
     @Test
+    @DisplayName("email로 member 조회")
     void findByEmail() {
-        //given - setUp()
+        //given
         //when
-        Optional<Member> optional = memberRepository.findByEmail("abc@abc.com");
-        Member findMember = optional.orElseGet(() -> Member.builder().build());
-        String expectedMemberName = findMember.getName();
+        Optional<Member> optional = memberRepository.findByEmail(EMAIL);
+        Member mem1 = optional.orElseThrow(NullPointerException::new);
         //then
-        Assertions.assertThat(expectedMemberName).isEqualTo("사용자");
-
+        Assertions.assertThat(mem1.getName()).isEqualTo(NAME);
     }
 
     @Test
+    @DisplayName("oauth2ClientId와 SnsType으로 member 조회")
     void findByOauth2ClientIdAndSnsType() {
-        //given - setUp()
+        //given
         //when
-        Optional<Member> optional = memberRepository.findByOauth2ClientIdAndSnsType("111", SnsType.KAKAOTALK);
-        Member findMember = optional.orElseGet(() -> Member.builder().build());
-        String expectedMemberName = findMember.getName();
+        Optional<Member> optional = memberRepository.findByOauth2ClientIdAndSnsType(OAUTH2_CLIENT_ID, SNS_TYPE);
+        Member mem1 = optional.orElseThrow(NullPointerException::new);
         //then
-        Assertions.assertThat(expectedMemberName).isEqualTo("사용자");
+        Assertions.assertThat(mem1.getName()).isEqualTo(NAME);
+    }
+
+    @Test
+    @DisplayName("oauth2ClientId로 member 조회")
+    void findByOauth2ClientId() {
+        //given
+        //when
+        Optional<Member> optional = memberRepository.findByOauth2ClientId(OAUTH2_CLIENT_ID);
+        Member mem1 = optional.orElseThrow(NullPointerException::new);
+        //then
+        Assertions.assertThat(mem1.getName()).isEqualTo(NAME);
     }
 
     @AfterEach
     void tearDown() {
-
+        memberRepository.delete(member);
     }
 }

--- a/server/src/test/java/com/soothee/member/service/MemberServiceImplTest.java
+++ b/server/src/test/java/com/soothee/member/service/MemberServiceImplTest.java
@@ -1,0 +1,129 @@
+package com.soothee.member.service;
+
+import com.soothee.common.constants.SnsType;
+import com.soothee.member.domain.Member;
+import com.soothee.member.repository.MemberRepository;
+import com.soothee.oauth2.domain.AuthenticatedUser;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource("classpath:application-test.properties")
+@SpringBootTest
+@Transactional
+class MemberServiceImplTest {
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private MemberRepository memberRepository;
+    private final String NAME = "사용자0";
+    private final String EMAIL = "abc@def.com";
+    private final SnsType SNS_TYPE = SnsType.KAKAOTALK;
+    private final String OAUTH2_CLIENT_ID = "111111";
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .name(NAME)
+                .email(EMAIL)
+                .oauth2ClientId(OAUTH2_CLIENT_ID)
+                .snsType(SNS_TYPE).build();
+        memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("OAuth2 로그인 시, 받은 정보로 회원 조회")
+    void getMemberForOAuth2() {
+
+    }
+
+    @Test
+    @DisplayName("회원 가입")
+    void saveMember() {
+        //given
+        Member newMember = Member.builder()
+                .email("def@def.com")
+                .name("새사용자")
+                .oauth2ClientId("22222")
+                .snsType(SnsType.GOOGLE).build();
+        //when
+        memberService.saveMember(newMember);
+        //then
+        Optional<Member> optional = memberRepository.findByEmail("def@def.com");
+        Member mem1 = optional.orElseThrow(NullPointerException::new);
+        Assertions.assertThat("22222").isEqualTo(mem1.getOauth2ClientId());
+    }
+
+    @Test
+    @DisplayName("회원 닉네임 수정")
+    void updateName() {
+        //given
+        String newName = "새 이름";
+        Optional<Member> optional1 = memberRepository.findByEmail(EMAIL);
+        Member mem1 = optional1.orElseThrow(NullPointerException::new);
+        //when
+        mem1.updateName(newName);
+        //then
+        Optional<Member> optional2 = memberRepository.findByEmail(EMAIL);
+        Member mem2 = optional2.orElseThrow(NullPointerException::new);
+        Assertions.assertThat(mem2.getName()).isEqualTo(newName);
+    }
+
+    @Test
+    @DisplayName("회원 다크모드 수정")
+    void updateDarkMode() {
+        //given
+        String isDarkY = "Y";
+        Optional<Member> optional1 = memberRepository.findByEmail(EMAIL);
+        Member mem1 = optional1.orElseThrow(NullPointerException::new);
+        //when
+        mem1.updateDarkModeYN(isDarkY);
+        //then
+        Optional<Member> optional2 = memberRepository.findByEmail(EMAIL);
+        Member mem2 = optional2.orElseThrow(NullPointerException::new);
+        Assertions.assertThat(mem2.getIsDark()).isEqualTo(isDarkY);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴")
+    void deleteMember() {
+        //given
+        Optional<Member> optional1 = memberRepository.findByEmail(EMAIL);
+        Member mem1 = optional1.orElseThrow(NullPointerException::new);
+        //when
+        mem1.deleteMember();
+        //then
+        Optional<Member> optional2 = memberRepository.findByEmail(EMAIL);
+        Member mem2 = optional2.orElseThrow(NullPointerException::new);
+        Assertions.assertThat(mem2.getIsDelete()).isEqualTo("Y");
+    }
+
+    @Test
+    @DisplayName("로그인한 회원의 모든 정보 조회")
+    void getAllMemberInfo() {
+    }
+
+    @Test
+    @DisplayName("로그인한 회원의 닉네임만 조회")
+    void getNicknameInfo() {
+    }
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.delete(member);
+    }
+}


### PR DESCRIPTION
## 📌 PR 개요
회원 관련 Domain, Service, Repository 별 단위 테스트 작성

## 📎 관련 이슈
관련 이슈가 있다면 이슈 번호를 기입해 주세요.  
`close #{KAN-86}`를 작성하면 요청이 merge된 후 이슈가 자동으로 close됩니다.

`resolve #(KAN-86)`

## 🔍 작업 내용
- [x] 회원 수정 삭제 성공 테스트 코드 작성
- [x] 회원 리포지토리 성공 테스트 코드 작성
- [x] 회원 서비스 성공 테스트 코드 작성

## ✅ 체크리스트
- [x] 코드 스타일 가이드에 맞게 작성했나요?
- [ ] 코드에 대한 주석을 달았나요?
- [ ] 문서가 업데이트되었나요? (해당하는 경우)
- [x] 테스트가 추가되었거나 기존 테스트가 통과하나요?

## 📝 참고 사항
아직 OAuth2 구현이 완벽하지 않고, OAuth2 승인 이후에 이루어지는 로직에 대해 테스트 하는 방법을 찾지 못해 추후에 보강할 것

