### PR TITLE
Feat: 회원 탈퇴 시, 사유 저장 기능 추가

### DIFF
--- a/server/src/main/java/com/soothee/member/controller/MemberController.java
+++ b/server/src/main/java/com/soothee/member/controller/MemberController.java
@@ -92,7 +92,8 @@ public class MemberController {
     @DeleteMapping("/delete")
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 시, 소프트 삭제, 따로 파라미터를 넣지 않아도 현재 로그인한 계정 정보를 이용함", security = @SecurityRequirement(name = "oauth2_auth"))
     @Parameters(value = {
-            @Parameter(name = "memberId", description = "탈퇴할 회원 일련번호", example = "memberId=1111", required = true, in = ParameterIn.QUERY)
+            @Parameter(name = "memberId", description = "탈퇴할 회원 일련번호", example = "memberId=1111", required = true, in = ParameterIn.QUERY),
+            @Parameter(name = "reasonId", description = "회원의 탈퇴 사유 일련번호", example = "reasonId=1", required = true, in = ParameterIn.QUERY)
     })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "요청 성공", content = @Content(mediaType = "text/plain")),
@@ -100,8 +101,9 @@ public class MemberController {
             @ApiResponse(responseCode = "403", description = "접근 오류", content = @Content(mediaType = "text/plain"))
     })
     public ResponseEntity<?> deleteMember(@RequestParam("memberId") Long memberId,
+                                          @RequestParam("reasonId") Long reasonId,
                                           @AuthenticationPrincipal AuthenticatedUser loginInfo) {
-        memberService.deleteMember(loginInfo, memberId);
+        memberService.deleteMember(loginInfo, memberId, reasonId);
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 }

--- a/server/src/main/java/com/soothee/member/domain/Member.java
+++ b/server/src/main/java/com/soothee/member/domain/Member.java
@@ -37,6 +37,10 @@ public class Member extends TimeEntity {
     @Column(name = "is_delete", nullable = false, length = 1)
     private String isDelete;
 
+    /** 삭제 사유 */
+    @Column(name = "reason_id", nullable = true)
+    private Long reasonId;
+
     /** 가입한 SNS */
     @Enumerated(EnumType.STRING)
     @Column(name = "sns_type", nullable = false)
@@ -85,7 +89,8 @@ public class Member extends TimeEntity {
     }
 
     /** 회원 삭제 */
-    public void deleteMember() {
+    public void deleteMember(Long reasonId) {
+        this.reasonId = reasonId;
         this.isDelete = "Y";
     }
 }

--- a/server/src/main/java/com/soothee/member/service/MemberService.java
+++ b/server/src/main/java/com/soothee/member/service/MemberService.java
@@ -47,9 +47,10 @@ public interface MemberService {
      * 회원 탈퇴</hr>
      *
      * @param loginInfo AuthenticatedUser : 로그인한 회원 정보
-     * @param memberId Long : 입력한 회원 일련번호
+     * @param memberId  Long : 입력한 회원 일련번호
+     * @param reasonId  Long : 입력한 탈퇴 사유
      */
-    void deleteMember(AuthenticatedUser loginInfo, Long memberId);
+    void deleteMember(AuthenticatedUser loginInfo, Long memberId, Long reasonId);
 
     /**
      * 로그인한 회원의 모든 정보 조회</hr>

--- a/server/src/main/java/com/soothee/member/service/MemberServiceImpl.java
+++ b/server/src/main/java/com/soothee/member/service/MemberServiceImpl.java
@@ -85,12 +85,12 @@ public class MemberServiceImpl implements MemberService {
      * @param memberId Long : 입력한 회원 일련번호
      */
     @Override
-    public void deleteMember(AuthenticatedUser loginInfo, Long memberId) {
+    public void deleteMember(AuthenticatedUser loginInfo, Long memberId, Long reasonId) {
         Member loginMember =  this.getLoginMember(loginInfo);
         if(this.isNotLoginMemberInfo(loginMember, memberId)) {
             throw new MyException(HttpStatus.BAD_REQUEST, MyErrorMsg.MISS_MATCH_MEMBER);
         }
-        loginMember.deleteMember();
+        loginMember.deleteMember(reasonId);
     }
 
     /**

--- a/server/src/main/resources/sql/init_info.sql
+++ b/server/src/main/resources/sql/init_info.sql
@@ -27,3 +27,10 @@ VALUES (NULL, 'sunny'),
        (NULL, 'rainy'),
        (NULL, 'thunder'),
        (NULL, 'snow');
+
+INSERT INTO del_reason
+VALUES (NULL, 'A'),
+       (NULL, 'B'),
+       (NULL, 'C'),
+       (NULL, 'D'),
+       (NULL, '기타');

--- a/server/src/main/resources/sql/table_setting.sql
+++ b/server/src/main/resources/sql/table_setting.sql
@@ -1,3 +1,9 @@
+CREATE TABLE del_reason
+(
+  reason_id INT AUTO_INCREMENT PRIMARY KEY,
+  content VARCHAR(255) NOT NULL
+);
+
 CREATE TABLE member
 (
     member_id INT AUTO_INCREMENT PRIMARY KEY,
@@ -5,11 +11,13 @@ CREATE TABLE member
     name VARCHAR(255) NOT NULL,
     is_dark VARCHAR(1) NOT NULL,
     is_delete VARCHAR(1) NOT NULL,
+    reason_id INT NULL,
     reg_date DATETIME NOT NULL,
     mod_date DATETIME NOT NULL,
     sns_type VARCHAR(255) NOT NULL,
     oauth2_client_id VARCHAR(255) NOT NULL,
-    role VARCHAR(10) NOT NULL
+    role VARCHAR(10) NOT NULL,
+    FOREIGN KEY (reason_id) REFERENCES  del_reason(reason_id)
 );
 
 CREATE TABLE weather

--- a/server/src/test/java/com/soothee/member/domain/MemberTest.java
+++ b/server/src/test/java/com/soothee/member/domain/MemberTest.java
@@ -79,7 +79,7 @@ class MemberTest {
         Member mem1 = memberRepository.findByMemberId(member.getMemberId()).orElseThrow();
 
         //when
-        mem1.deleteMember();
+        mem1.deleteMember(1L);
 
         //then
         Member mem2 = memberRepository.findByMemberId(member.getMemberId()).orElseThrow();

--- a/server/src/test/java/com/soothee/member/service/MemberServiceImplTest.java
+++ b/server/src/test/java/com/soothee/member/service/MemberServiceImplTest.java
@@ -105,7 +105,7 @@ class MemberServiceImplTest {
         Optional<Member> optional1 = memberRepository.findByEmail(EMAIL);
         Member mem1 = optional1.orElseThrow(NullPointerException::new);
         //when
-        mem1.deleteMember();
+        mem1.deleteMember(1L);
         //then
         Optional<Member> optional2 = memberRepository.findByEmail(EMAIL);
         Member mem2 = optional2.orElseThrow(NullPointerException::new);


### PR DESCRIPTION
## 📌 PR 개요
회원 탈퇴 시, 선택하는 회원 탈퇴 사유를 member Table에 소프트 삭제 시, 저장

## 📎 관련 이슈
관련 이슈가 있다면 이슈 번호를 기입해 주세요.  
`close #{KAN-95}`를 작성하면 요청이 merge된 후 이슈가 자동으로 close됩니다.

`resolve #(KAN-95)`

## 🔍 작업 내용
- [x] DB member Table에 회원 탈퇴 사유 Column 추가
- [x] DB reason Table 추가
- [x] 회원 탈퇴 로직에 회원 탈퇴 사유 저장 기능 추가

## ✅ 체크리스트
- [x] 코드 스타일 가이드에 맞게 작성했나요?
- [x] 코드에 대한 주석을 달았나요?
- [x] 문서가 업데이트되었나요? (해당하는 경우)
- [x] 테스트가 추가되었거나 기존 테스트가 통과하나요?

## 📝 참고 사항

